### PR TITLE
Resized the snake and the apple to fit with the grid

### DIFF
--- a/src/SnakeGame.js
+++ b/src/SnakeGame.js
@@ -71,7 +71,7 @@ const GameState = () => {
     const drawSnake = () => {
       snake.forEach((snakePart) => {
         ctx.beginPath();
-        ctx.rect(snakePart.x, snakePart.y, 14, 14);
+        ctx.rect(snakePart.x, snakePart.y, 8, 8);
         ctx.fillStyle = "#90EE90";
         ctx.fill();
         ctx.closePath();
@@ -80,7 +80,7 @@ const GameState = () => {
 
     const drawApple = () => {
       ctx.beginPath();
-      ctx.rect(apple.x, apple.y, 14, 14);
+      ctx.rect(apple.x, apple.y, 8, 8);
       ctx.fillStyle = "#FF0000";
       ctx.fill();
       ctx.closePath();


### PR DESCRIPTION
Changed the size of the snake and the apple in SnakeGame.js.

Previously: Snake size was large that it overlaps the snake's body and extends beyond the walls (which the snake should have been hit.
Now: Snake size is lowered to match the grid and visually identify that the snake square size is no longer touching beyond the grid's walls.